### PR TITLE
Fix: Disable HardwareManager to resolve flash cards error

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -51,8 +51,8 @@
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-L_pJI1QF.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Doeyv1zg.css">
+    <script type="module" crossorigin src="/assets/index-D9ti8KrB.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BFKTarz-.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { GlobalMusicProvider } from './contexts/GlobalMusicContext';
-import { HardwareManager } from './hardware';
+// Temporarily disable HardwareManager to fix flash cards
+// import { HardwareManager } from './hardware';
 import { audioEngine, TransportState } from './utils/audioEngine';
 import { WelcomeScreen } from './components/Welcome/WelcomeScreen';
 import { JamSession } from './components/JamSession/JamSession';
@@ -300,7 +301,8 @@ function App() {
   return (
     <>
     <GlobalMusicProvider>
-      <HardwareManager>
+      {/* Temporarily disabled HardwareManager to fix flash cards */}
+      {/* <HardwareManager> */}
         {/* Username Modal */}
         <UsernameModal
           isOpen={showUsernameModal}
@@ -501,7 +503,7 @@ function App() {
           }
         />
       </Routes>
-      </HardwareManager>
+      {/* </HardwareManager> */}
     </GlobalMusicProvider>
 
     {/* Announcement Banner */}

--- a/src/components/IsometricSequencer/IsometricSequencer.tsx
+++ b/src/components/IsometricSequencer/IsometricSequencer.tsx
@@ -206,11 +206,13 @@ export const IsometricSequencer: React.FC<IsometricSequencerProps> = ({ onBack, 
   // Hardware controller settings state
   const [showHardwareSelector, setShowHardwareSelector] = useState(false);
 
-  // Hardware Manager integration (Story 8.0)
-  const { controllers } = useHardwareContext();
-  const activeController = controllers.find(c => c.connectionStatus === 'connected');
-  const apc40Controller = activeController; // For backward compatibility with existing code
-  const apc40Connected = activeController?.connectionStatus === 'connected';
+  // Hardware Manager integration (Story 8.0) - TEMPORARILY DISABLED
+  // const { controllers } = useHardwareContext();
+  // const activeController = controllers.find(c => c.connectionStatus === 'connected');
+  // const apc40Controller = activeController; // For backward compatibility with existing code
+  // const apc40Connected = activeController?.connectionStatus === 'connected';
+  const apc40Controller = null;
+  const apc40Connected = false;
   const [apc40Rotated, setAPC40Rotated] = useState(false);
 
   // Sound engine state


### PR DESCRIPTION
Temporarily disables HardwareManager which was causing errors on the flash cards page.

The HardwareErrorBoundary was catching an error and displaying 'Hardware Module Error' on page load. This fix:
- Comments out HardwareManager wrapper in App.tsx
- Disables hardware context in IsometricSequencer
- Allows flash cards to load properly

We'll need to investigate the root cause and re-enable hardware support properly in a future PR.